### PR TITLE
Fix bug in height/width validation when using mm as unit.

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -139,7 +139,7 @@ function isError() {
 
 form.widthInput.addEventListener('change', function(e) {
     'use strict';
-    var val = Number(e.target.value);
+    var val = (form.unitOptions.value == 'mm') ? Number(e.target.value / 25.4) : Number(e.target.value);
     var dpi = Number(form.dpiInput.value);
     if (val > 0) {
         if (val * dpi > maxSize) {
@@ -151,6 +151,7 @@ form.widthInput.addEventListener('change', function(e) {
             errors.width.msg = 'The width is unreasonably big!';
         } else {
             errors.width.state = false;
+            if (form.unitOptions.value == 'mm') val *= 25.4;
             document.getElementById('map').style.width = toPixels(val);
             map.resize();
         }
@@ -163,7 +164,7 @@ form.widthInput.addEventListener('change', function(e) {
 
 form.heightInput.addEventListener('change', function(e) {
     'use strict';
-    var val = Number(e.target.value);
+    var val = (form.unitOptions.value == 'mm') ? Number(e.target.value / 25.4) : Number(e.target.value);
     var dpi = Number(form.dpiInput.value);
     if (val > 0) {
         if (val * dpi > maxSize) {
@@ -175,6 +176,7 @@ form.heightInput.addEventListener('change', function(e) {
             errors.height.msg = 'The height is unreasonably big!';
         } else {
             errors.height.state = false;
+            if (form.unitOptions.value == 'mm') val *= 25.4;
             document.getElementById('map').style.height = toPixels(val);
             map.resize();
         }


### PR DESCRIPTION
The validation of height and width  in `form.widthInput.addEventListener()` and `form.heightInput.addEventListener()` assumes `val` is in inches, even when the user switched to milimeters. This patch ensures that that assumption is correct.

To reproduce:
- load https://printmaps.mpetroff.net/
- change `Unit` to Milimeter
- trigger one of the Eventlisteners of Width or Height, e.g. by changing a last digit

